### PR TITLE
Changes to enable XBOX version of Universal Hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGETPATH = firmware
 
 # The teensy version to use, 30, 31, or LC
-TEENSY = 31
+TEENSY = LC
 
 # Device type: USB (wired) or BT (bluetooth)
 TYPE = USB
@@ -32,7 +32,7 @@ else
 endif
 
 # The name of your project (used to name the compiled .hex file)
-TARGET = csw.teensy$(TEENSY)_$(TYPE)
+TARGET = csw.SRMteensy$(TEENSY)_$(TYPE)
 
 #************************************************************************
 # Location of Teensyduino utilities, Toolchain, and Arduino Libraries.

--- a/csw.cpp
+++ b/csw.cpp
@@ -1,0 +1,550 @@
+#line 1 "csw.cpp"
+/* 
+ * Copyright (C) 2015 darknao
+ * https://github.com/darknao/btClubSportWheel
+ * 
+ * This file is part of btClubSportWheel.
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "WProgram.h"
+#include "Arduino.h"
+
+#include "fanatec.h"
+#include "iWRAP.h"
+
+
+/* WT12 */
+#define WT12 Serial1
+#define CTS 18
+
+uint8_t iwrap_mode = IWRAP_MODE_MUX;
+
+uint8_t hid_data[35];
+int16_t bt_delay = 0;
+uint32_t max_delay = 150000; // overhead if below 120ms
+// 400 is too short with fanaleds
+
+bool in_changed;
+bool bt_retry; // useless too
+
+int iwrap_out(int len, unsigned char *data);
+void hid_output(uint8_t link_id, uint16_t data_length, const uint8_t *data);
+void my_iwrap_evt_ring(uint8_t link_id, const iwrap_address_t *address, uint16_t channel, const char *profile);
+void my_iwrap_evt_hid_suspend(uint8_t link_id);
+void my_iwrap_rsp_list_result(uint8_t link_id, const char *mode, uint16_t blocksize, uint32_t elapsed_time, uint16_t local_msc, uint16_t remote_msc, const iwrap_address_t *bd_addr, uint16_t channel, uint8_t direction, uint8_t powermode, uint8_t role, uint8_t crypt, uint16_t buffer, uint8_t eretx);
+int my_iwrap_debug(const char *data);
+void my_iwrap_evt_no_carrier(uint8_t link_id, uint16_t error_code, const char *message);
+
+void bt_button(uint8_t button, bool val);
+void bt_X(unsigned int val);
+void bt_Y(unsigned int val);
+void bt_hat(int val);
+void bt_setWheel(unsigned int val);
+/* END WT12 */
+
+
+void setup();
+void loop();
+void idle();
+
+csw_in_t wheel_in;
+csw_out_t wheel_out;
+bool bt_connected;
+bool got_hid;
+uint32_t timing;
+uint32_t timing_bt;
+
+uint8_t hid_pck[7];
+
+void setup() {
+  fsetup();
+
+  /* 8 Extra Buttons
+    can be connected 
+    from pin 2 to pin 9 */
+  for (int pin = 2; pin <= 9; ++pin)
+  {
+    pinMode(pin, INPUT_PULLUP);
+  }
+
+  /* WT12 */
+  #ifndef IS_USB
+  pinMode (CTS, INPUT);
+  WT12.begin(115200, SERIAL_8N1);
+  WT12.attachRts(19);
+
+  // callback
+  iwrap_output = iwrap_out;
+  iwrap_evt_hid_output = hid_output;
+  iwrap_evt_ring = my_iwrap_evt_ring;
+  iwrap_evt_hid_suspend = my_iwrap_evt_hid_suspend;
+  iwrap_rsp_list_result = my_iwrap_rsp_list_result;
+  iwrap_evt_no_carrier = my_iwrap_evt_no_carrier;
+
+  // prebuild HID packet
+  hid_data[0] = 0x9f;
+  hid_data[1] = 0x21;
+  hid_data[2] = 0xa1;
+
+  in_changed = false;
+  bt_retry = false; // useless
+
+  #else
+  Joystick.useManualSend(true);
+  #endif // IS_USB
+  
+  // prebuild output packet
+  memset(wheel_out.raw, 0, sizeof(csw_out_t));
+  wheel_out.header = 0xa5;
+  wheel_out.id = 0x00;
+  //wheel_out.leds = 0xffff;
+  got_hid = false;
+  
+  // debug
+  #ifdef HAS_DEBUG
+  //iwrap_debug = my_iwrap_debug;
+  Serial.begin(115200);
+  Serial.println("MCU Ready");  
+  delay(5000);
+  Serial.println("check for active connection...");
+  #endif
+
+  #ifndef IS_USB
+  bt_connected = false;
+  iwrap_send_command("LIST", iwrap_mode);
+  #else
+    bt_connected = true;
+  #endif
+  //iwrap_send_command("SET BT PAIR", iwrap_mode);
+  timing = micros();
+  timing_bt = millis();
+}
+
+
+byte rotary_debounce = 0;
+int8_t rotary_value = 0;
+uint8_t main_link_id = 1;
+bool Press[48];
+
+void loop() {
+
+  if(bt_connected) {
+    // Read Fanatec Packet
+    transfer_data(&wheel_out, &wheel_in, sizeof(wheel_out.raw));
+    #ifdef IS_USB
+      // Fetching HID packet
+      uint16_t hid_size;
+      hid_size = Joystick.recv(&hid_pck, 0);
+      if(hid_size > 0) hid_output(1, hid_size, hid_pck);
+    #endif
+
+    if(wheel_in.header == 0xa5){
+      bt_setWheel(wheel_in.id);
+      // Left stick
+      bt_X(255-(wheel_in.axisX+127));
+      bt_Y(wheel_in.axisY+127);
+  
+      // All buttons
+      bt_button(1, wheel_in.buttons[0]&0x80);
+      bt_button(2, wheel_in.buttons[0]&0x40);
+      bt_button(3, wheel_in.buttons[0]&0x20);
+      bt_button(7, wheel_in.buttons[1]&0x20);
+      bt_button(8, wheel_in.buttons[1]&0x10);      
+      bt_button(10, wheel_in.buttons[1]&0x02);      
+      bt_button(12, wheel_in.buttons[2]&0x04);
+      bt_button(13, wheel_in.buttons[2]&0x02);
+      bt_button(14, wheel_in.buttons[2]&0x20);
+      // paddles shitfer 
+      bt_button(15, wheel_in.buttons[1]&0x08);
+      bt_button(16, wheel_in.buttons[1]&0x01);
+      if(wheel_in.id != XBOXHUB){
+        bt_button(4, wheel_in.buttons[0]&0x10);
+        bt_button(5, wheel_in.buttons[1]&0x80);
+        bt_button(6, wheel_in.buttons[1]&0x40);
+        bt_button(9, wheel_in.buttons[1]&0x04);
+        bt_button(11, wheel_in.buttons[2]&0x08);
+      }         
+      
+      if(wheel_in.id == UNIHUB){
+        // Uni Hub buttons
+        // BUT_5 array (optional 3 buttons)
+        bt_button(19, wheel_in.btnHub[0]&0x08);
+        bt_button(20, wheel_in.btnHub[0]&0x10);
+        bt_button(21, wheel_in.btnHub[0]&0x20);	
+        // Playstation buttons
+        bt_button(22, wheel_in.btnPS[0]&0x01);
+        bt_button(23, wheel_in.btnPS[0]&0x02);
+        bt_button(24, wheel_in.btnPS[0]&0x04);
+        bt_button(25, wheel_in.btnPS[0]&0x08);
+        bt_button(26, wheel_in.btnPS[0]&0x10);
+        bt_button(27, wheel_in.btnPS[0]&0x20);
+        bt_button(28, wheel_in.btnPS[0]&0x40);
+        bt_button(29, wheel_in.btnPS[0]&0x80);
+        bt_button(30, wheel_in.btnPS[1]&0x01);
+        bt_button(31, wheel_in.btnPS[1]&0x02);
+        bt_button(32, wheel_in.btnPS[1]&0x04);
+        bt_button(33, wheel_in.btnPS[1]&0x08);
+        bt_button(34, wheel_in.btnPS[1]&0x10);
+        bt_button(35, wheel_in.btnPS[1]&0x20);
+        bt_button(36, wheel_in.btnPS[1]&0x40);
+        bt_button(37, wheel_in.btnPS[1]&0x80);
+      }
+      if(wheel_in.id == XBOXHUB){ 
+        bt_button(4, wheel_in.btnPS[1]&0x80 || wheel_in.buttons[0]&0x10); 
+        bt_button(5, wheel_in.btnPS[1]&0x02 || wheel_in.buttons[1]&0x80);
+        bt_button(6, wheel_in.btnPS[0]&0x40 || wheel_in.buttons[1]&0x40);
+	bt_button(9, wheel_in.btnPS[0]&0x80 || wheel_in.buttons[1]&0x04); 
+        bt_button(11, wheel_in.btnPS[1]&0x01 || wheel_in.buttons[2]&0x08);   
+        bt_button(19, wheel_in.btnHub[0]&0x08);
+        bt_button(20, wheel_in.btnHub[0]&0x10);
+        bt_button(21, wheel_in.btnHub[0]&0x20);
+        bt_button(22, wheel_in.btnPS[0]&0x01);
+        bt_button(23, wheel_in.btnPS[0]&0x02);
+        bt_button(24, wheel_in.btnPS[0]&0x04);
+        bt_button(25, wheel_in.btnPS[0]&0x08);
+        bt_button(26, wheel_in.btnPS[0]&0x10);
+        bt_button(27, wheel_in.btnPS[0]&0x20);
+        bt_button(28, wheel_in.btnPS[1]&0x20);
+        bt_button(29, wheel_in.btnPS[1]&0x40);        
+        bt_button(30, wheel_in.btnPS[1]&0x08);
+        bt_button(31, wheel_in.btnPS[1]&0x10);
+        bt_button(32, wheel_in.btnHub[1]&0x08 || wheel_in.btnPS[1]&0x04);
+      }
+      
+      if( rotary_debounce > 0 && rotary_debounce <= 50){
+       rotary_debounce++;
+      } else if (rotary_debounce > 50){
+        rotary_debounce = 0;
+      }
+
+      if (rotary_debounce == 0) 
+      {    
+        //rotary_debounce = 0;
+        rotary_value = wheel_in.encoder;
+        
+        bt_button(17, rotary_value==-1);
+        bt_button(18, rotary_value==1);
+        if (rotary_value != 0){
+          #ifdef HAS_DEBUG
+            Serial.println(String("DBNCE START!!!!!!!!!ROTARY : ") + rotary_value);
+          #endif
+          rotary_debounce++;
+        }
+      }
+
+      int16_t hat;
+      switch (wheel_in.buttons[0]&0x0f){
+        case 0: hat=0xFF;break;
+        case 1: hat=0;break;
+        case 2: hat=6;break;
+        case 4: hat=2;break;
+        case 8: hat=4;break;
+        default: hat=0xFF;
+      }
+      bt_hat(hat);
+      
+      //Serial.println(String("button: ") + hid_data[3]);
+
+      
+    }
+  
+    // 8 Extra Buttons
+    for (int i = 0; i < 8; ++i)
+    {
+      bt_button(38+i, !digitalRead(2+i));
+    }
+
+    // Send HID report (all inputs)
+    #ifdef IS_USB
+      Joystick.send_now();
+      //rotary_debounce = 0;
+    #else
+    uint32_t timout;
+    timout = micros() - timing;
+      if(timout > max_delay || (in_changed && timout > 10000))
+      {
+        //hid_data[3] = (hid_data[3]+1)&0xff;
+        iwrap_send_data(main_link_id, sizeof(hid_data), hid_data, iwrap_mode);
+        timing = micros();
+        bt_delay = 0;
+        #ifdef HAS_DEBUG
+          if (rotary_debounce!=0)Serial.println(String("RESET!!!!!!!!!ROTARY : ") + rotary_value);
+          if (in_changed)Serial.println("input sent");
+        #endif
+        in_changed = false;
+        //rotary_debounce = 0;
+      }
+      bt_delay++;
+
+      #endif
+  }
+
+  #ifndef IS_USB
+  // Read WT12 incoming data
+  uint16_t result;
+
+  while((result = WT12.read()) < 256 && !got_hid) iwrap_parse(result & 0xFF, iwrap_mode);
+  if(got_hid) got_hid = false;
+  #endif
+  //timing = micros() - timing;
+  //if(timing > 550)  Serial.println(String("timing: ") + timing);
+  // some delay
+  idle();
+}
+
+void bt_button(uint8_t button, bool val) {
+  #ifdef IS_USB
+    Joystick.button(button, val);
+  #else
+  uint8_t old;
+  if (--button >= 48) return;
+    if (button >= 40) {
+      old = hid_data[8];
+      if (val) hid_data[8] |= (0x1 << (button-40));
+      else hid_data[8] &= ~(0x1 << (button-40));
+      if (old != hid_data[8]){
+        in_changed = true;
+        #ifdef HAS_DEBUG
+          Serial.println(String("bt_button: new input! ") + old + " -> " + hid_data[8]);
+        #endif
+      }
+  } else if (button >= 32) {
+      old = hid_data[7];
+      if (val) hid_data[7] |= (0x1 << (button-32));
+      else hid_data[7] &= ~(0x1 << (button-32));
+      if (old != hid_data[7]){
+        in_changed = true;
+        #ifdef HAS_DEBUG
+          Serial.println(String("bt_button: new input! ") + old + " -> " + hid_data[7]);
+        #endif
+      }
+  } else if (button >= 24) {
+      old = hid_data[6];
+      if (val) hid_data[6] |= (0x1 << (button-24));
+      else hid_data[6] &= ~(0x1 << (button-24));
+      if (old != hid_data[6]){
+        in_changed = true;
+        #ifdef HAS_DEBUG
+          Serial.println(String("bt_button: new input! ") + old + " -> " + hid_data[6]);
+        #endif
+      }
+  } else if (button >= 16) {
+      old = hid_data[5];
+      if (val) hid_data[5] |= (0x1 << (button-16));
+      else hid_data[5] &= ~(0x1 << (button-16));
+      if (old != hid_data[5]){
+        in_changed = true;
+        #ifdef HAS_DEBUG
+          Serial.println(String("bt_button: new input! ") + old + " -> " + hid_data[5]);
+        #endif
+      }
+  } else if (button >= 8) {
+      old = hid_data[4];
+      if (val) hid_data[4] |= (0x1 << (button-8));
+      else hid_data[4] &= ~(0x1 << (button-8));
+      if (old != hid_data[4]){
+        in_changed = true;
+        #ifdef HAS_DEBUG
+          Serial.println(String("bt_button: new input! ") + old + " -> " + hid_data[4]);
+        #endif
+      }
+  } else {
+      old = hid_data[3];
+      if (val) hid_data[3] |= (0x1 << (button));
+      else hid_data[3] &= ~(0x1 << (button));
+      if (old != hid_data[3]){
+        in_changed = true;
+        #ifdef HAS_DEBUG
+          Serial.println(String("bt_button: new input! ") + old + " -> " + hid_data[3]);
+        #endif
+      }
+  }
+  #endif
+}
+
+void bt_X(unsigned int val) {
+  #ifdef IS_USB
+    Joystick.X(val);
+  #else
+  uint8_t old = hid_data[9];
+  hid_data[9] = val & 0xFF;
+  if (old != hid_data[9]) {
+    in_changed = true;
+    #ifdef HAS_DEBUG
+      Serial.println(String("bt_X: new input! ") + old + " -> " + hid_data[9]);
+    #endif
+  }
+  #endif
+}
+
+void bt_Y(unsigned int val) {
+  #ifdef IS_USB
+    Joystick.Y(val);
+  #else
+  uint8_t old = hid_data[10];
+  hid_data[10] = val & 0xFF;
+  if (old != hid_data[10]){
+    in_changed = true;   
+    #ifdef HAS_DEBUG
+      Serial.println(String("bt_Y: new input! ") + old + " -> " + hid_data[10]);
+    #endif
+  } 
+  #endif
+}
+
+void bt_hat(int val) {
+  #ifdef IS_USB
+    Joystick.hat(val);
+  #else
+  uint8_t old = hid_data[11];
+  hid_data[11] = val & 0xFF;
+  if (old != hid_data[11]){
+    in_changed = true;   
+    #ifdef HAS_DEBUG
+      Serial.println(String("bt_hat: new input! ") + old + " -> " + hid_data[11]);
+    #endif
+  } 
+  #endif
+}
+
+void bt_setWheel(unsigned int val) {
+  wheel_out.id = val & 0xFF;
+  #ifdef IS_USB
+    Joystick.setWheel(val);
+  #else
+    uint8_t old = hid_data[32];
+    hid_data[32] = wheel_out.id;
+    if (old != hid_data[32]){
+      in_changed = true;   
+      #ifdef HAS_DEBUG
+        Serial.println(String("bt_setWheel: new input! ") + old + " -> " + hid_data[32]);
+      #endif
+    }
+  #endif 
+}
+        
+int iwrap_out(int len, unsigned char *data) {
+  // iWRAP output to module goes through software serial
+  int nbytes = WT12.availableForWrite();
+
+  if(digitalRead(CTS) == LOW && nbytes >= len){
+      nbytes = WT12.write(data, len);
+      bt_retry = false;
+      //Serial.println(String("sent : ") + nbytes );
+  } else {
+      bt_retry = true;
+      #ifdef HAS_DEBUG
+      Serial.println(String("[!] Throttling (")+max_delay+")");
+      #endif
+      bt_delay = -32000;
+      max_delay++;
+      //delay(1000);
+  }
+  //got_hid = true;
+  return nbytes;
+}
+    
+void hid_output(uint8_t link_id, uint16_t data_length, const uint8_t *data) {
+  #ifdef HAS_DEBUG
+  timing_bt = millis() - timing_bt;
+  if(timing_bt <= 35){
+    Serial.println(String("[W] low timing :") + timing_bt + "ms ");
+    //delay(10+(35-timing_bt));
+  }
+  #endif
+  if(data[2] == 0x01 && data[3] == 0x02){
+      // 7 seg
+      wheel_out.disp[0] = (data[4] & 0xff);
+      wheel_out.disp[1] = (data[5] & 0xff);
+      wheel_out.disp[2] = (data[6] & 0xff);
+      #ifdef HAS_DEBUG
+        Serial.println(String("HID display: " )+ wheel_out.disp[0]+":"+wheel_out.disp[1]+":"+wheel_out.disp[2]);
+      #endif
+  } else if(data[2] == 0x01 && data[3] == 0x03){
+      // rumbles
+    if (wheel_out.id != UNIHUB){
+      wheel_out.rumble[0] = (data[4] & 0xff);
+      wheel_out.rumble[1] = (data[5] & 0xff);
+    }
+      #ifdef HAS_DEBUG
+        Serial.println(String("HID rumbles: " )+ wheel_out.rumble[0]+":"+wheel_out.rumble[1]);
+      #endif
+  } else if(data[2] == 0x08){
+      // Rev Lights
+    if (wheel_out.id != UNIHUB){
+      wheel_out.leds = (data[3] & 0xff) << 8 | (data[4] & 0xff);
+      //ftx_pck[5] = (hid_pck[4] & 0xff);
+      //ftx_pck[6] = (hid_pck[3] & 0xff);
+    }
+      #ifdef HAS_DEBUG
+        Serial.println(String("HID leds   : " )+ wheel_out.leds);
+      #endif
+  } else {
+      #ifdef HAS_DEBUG
+        Serial.print(String("[!] HID Unknown from " )+ link_id + " (size:" + data_length + ") : ");
+        
+        for(int i=0; i<data_length; i++) {
+          Serial.print(data[i], HEX);
+          Serial.print(":");
+          
+        }
+        Serial.println();
+      #endif
+  }
+  timing_bt = millis();
+}
+
+#ifdef HAS_DEBUG
+int my_iwrap_debug(const char *data) {
+  return Serial.print(data);
+}
+#endif
+
+void my_iwrap_evt_ring(uint8_t link_id, const iwrap_address_t *address, uint16_t channel, const char *profile) {
+  #ifdef HAS_DEBUG
+  Serial.println(String("Connection from " )+ link_id);
+  #endif
+  bt_connected = true;
+}
+
+void my_iwrap_evt_hid_suspend(uint8_t link_id) {
+  #ifdef HAS_DEBUG
+  Serial.println(String("Disconnection from " )+ link_id);
+  #endif
+  bt_connected = false;
+}
+
+void my_iwrap_evt_no_carrier(uint8_t link_id, uint16_t error_code, const char *message) {
+  #ifdef HAS_DEBUG
+  Serial.println(String("Disconnection from " )+ link_id);
+  #endif
+  bt_connected = false;
+}
+
+void my_iwrap_rsp_list_result(uint8_t link_id, const char *mode, uint16_t blocksize, uint32_t elapsed_time, uint16_t local_msc, uint16_t remote_msc, const iwrap_address_t *bd_addr, uint16_t channel, uint8_t direction, uint8_t powermode, uint8_t role, uint8_t crypt, uint16_t buffer, uint8_t eretx) {
+  #ifdef HAS_DEBUG
+  Serial.println(String("Already connected to ") + link_id);
+  #endif
+  bt_connected = true;
+}
+
+void idle() {
+  #ifndef IS_USB
+    delay(1);
+  #endif
+}
+
+

--- a/fanatec.cpp
+++ b/fanatec.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2015 darknao
+ * https://github.com/darknao/btClubSportWheel
+ *
+ * This file is part of btClubSportWheel.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fanatec.h"
+
+SPISettings settingsA(12000000, MSBFIRST, SPI_MODE0);
+
+// CRC lookup table with polynomial of 0x131
+PROGMEM prog_uchar _crc8_table[256] = {
+  0, 94, 188, 226, 97, 63, 221, 131,
+  194, 156, 126, 32, 163, 253, 31, 65,
+  157, 195, 33, 127, 252, 162, 64, 30,
+  95, 1, 227, 189, 62, 96, 130, 220,
+  35, 125, 159, 193, 66, 28, 254, 160,
+  225, 191, 93, 3, 128, 222, 60, 98,
+  190, 224, 2, 92, 223, 129, 99, 61,
+  124, 34, 192, 158, 29, 67, 161, 255,
+  70, 24, 250, 164, 39, 121, 155, 197,
+  132, 218, 56, 102, 229, 187, 89, 7,
+  219, 133, 103, 57, 186, 228, 6, 88,
+  25, 71, 165, 251, 120, 38, 196, 154,
+  101, 59, 217, 135, 4, 90, 184, 230,
+  167, 249, 27, 69, 198, 152, 122, 36,
+  248, 166, 68, 26, 153, 199, 37, 123,
+  58, 100, 134, 216, 91, 5, 231, 185,
+  140, 210, 48, 110, 237, 179, 81, 15,
+  78, 16, 242, 172, 47, 113, 147, 205,
+  17, 79, 173, 243, 112, 46, 204, 146,
+  211, 141, 111, 49, 178, 236, 14, 80,
+  175, 241, 19, 77, 206, 144, 114, 44,
+  109, 51, 209, 143, 12, 82, 176, 238,
+  50, 108, 142, 208, 83, 13, 239, 177,
+  240, 174, 76, 18, 145, 207, 45, 115,
+  202, 148, 118, 40, 171, 245, 23, 73,
+  8, 86, 180, 234, 105, 55, 213, 139,
+  87, 9, 235, 181, 54, 104, 138, 212,
+  149, 203, 41, 119, 244, 170, 72, 22,
+  233, 183, 85, 11, 136, 214, 52, 106,
+  43, 117, 151, 201, 74, 20, 246, 168,
+  116, 42, 200, 150, 21, 75, 169, 247,
+  182, 232, 10, 84, 215, 137, 107, 53
+};
+
+// return CRC8 from buf
+uint8_t crc8(const uint8_t* buf, uint8_t length) {
+    uint8_t crc = 0xff;
+    while (length) {
+        crc = pgm_read_byte_near(_crc8_table + (*buf ^ crc));
+        buf++;
+        length--;
+    }
+    return crc;
+}
+
+// Send/Receive Fanatec Packet
+void transfer_data(csw_out_t* out, csw_in_t* in, uint8_t length) {
+  //uint8_t data[length]; // 32 bytes of data, 1 byte for CRC
+  //uint8_t crc;
+
+  // get CRC
+  out->crc = crc8(out->raw, length-1);
+
+  //memcpy(data, out, length);
+
+  // append CRC to data packet
+  //data[length-1] = crc;
+
+  // Send packet
+  digitalWrite(CS, LOW);
+  SPI.beginTransaction(settingsA);
+  for(int i=0; i<length; i++) {
+    in->raw[i] = SPI.transfer(out->raw[i]);
+  }
+  SPI.endTransaction();
+  digitalWrite(CS, HIGH);
+  // Bit shifting
+
+  for (int i = 0;  i < length - 1;  ++i) {
+     in->raw[i] = (in->raw[i] << 1) | ((in->raw[i+1] >> 7) & 1);
+  } 
+
+}
+
+/*
+void transfer_data2(const uint8_t* out, uint8_t* in, uint8_t length) {
+  uint8_t data[length]; // 32 bytes of data, 1 byte for CRC
+  uint8_t crc;
+  int i;
+
+  // get CRC
+  crc = crc8(out, length-1);
+
+  memcpy(data, out, length);
+
+  // append CRC to data packet
+  data[length-1] = crc;
+
+  // Send packet
+  // basic version
+  SPIFIFO.clear();
+  // Warm up the FIFO with 3 write
+  SPIFIFO.write(data[0], SPI_CONTINUE);
+  SPIFIFO.write(data[1], SPI_CONTINUE);
+  SPIFIFO.write(data[2], SPI_CONTINUE);
+  SPIFIFO.read();
+  for(i=3; i<length-1; i++) {
+    SPIFIFO.write(data[i], SPI_CONTINUE);
+    in[i-3] = SPIFIFO.read();
+  }
+  SPIFIFO.write(data[i]);
+  in[i++] = SPIFIFO.read();
+  in[i++] = SPIFIFO.read();
+  in[i++] = SPIFIFO.read();
+}
+*/
+
+void fsetup() {
+
+  pinMode(CS, OUTPUT);
+  digitalWrite(CS,HIGH); 
+  SPI.begin();
+  SPI.setClockDivider(0);
+
+
+}

--- a/fanatec.h
+++ b/fanatec.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 darknao
+ * https://github.com/darknao/btClubSportWheel
+ *
+ * This file is part of btClubSportWheel.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _FANATEC_H_
+#define _FANATEC_H_
+
+#include <SPI.h>
+#define CS 10
+
+#define FORMULA_RIM 1
+#define BMW_RIM 2
+#define RSR_RIM 3
+#define UNIHUB 4
+#define XBOXHUB 6
+
+#pragma pack(push, 1)
+struct csw_in_t {
+  union {
+    struct {
+      //bool unk:1;
+      uint8_t header;
+      uint8_t id;
+      uint8_t buttons[3];
+      int8_t axisX;
+      int8_t axisY;
+      int8_t encoder;
+      uint8_t btnHub[2];
+      uint8_t btnPS[2];
+      uint8_t btnXBOX[2];	
+      uint8_t garbage[20];
+      uint8_t crc;
+      // +3 padding bits
+    };
+    uint8_t raw[34];
+  };
+};
+
+struct csw_out_t {
+  union {
+    struct {
+      uint8_t header;
+      uint8_t id;
+      uint8_t disp[3];
+      uint16_t leds;
+      uint8_t rumble[2];
+
+      uint8_t nothing[23];
+      uint8_t crc;
+    };
+    uint8_t raw[33];
+  };
+};
+#pragma pack(pop)
+
+uint8_t crc8(const uint8_t* buf, uint8_t length);
+void transfer_data(csw_out_t* out, csw_in_t* in, uint8_t length);
+
+
+void fsetup();
+#endif

--- a/usb_desc.h
+++ b/usb_desc.h
@@ -1,0 +1,177 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2013 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _usb_desc_h_
+#define _usb_desc_h_
+
+#if F_CPU >= 20000000
+
+// This header is NOT meant to be included when compiling
+// user sketches in Arduino.  The low-level functions
+// provided by usb_dev.c are meant to be called only by
+// code which provides higher-level interfaces to the user.
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef USB_DISABLED
+
+#define ENDPOINT_UNUSED     0x00
+#define ENDPOINT_TRANSIMIT_ONLY   0x15
+#define ENDPOINT_RECEIVE_ONLY   0x19
+#define ENDPOINT_TRANSMIT_AND_RECEIVE 0x1D
+
+/*
+To modify a USB Type to have different interfaces, start in this
+file.  Delete the XYZ_INTERFACE lines for any interfaces you
+wish to remove, and copy them from another USB Type for any you
+want to add.
+
+Give each interface a unique number, and edit NUM_INTERFACE to
+reflect the number of interfaces.
+
+Within each interface, make sure it uses a unique set of endpoints.
+Edit NUM_ENDPOINTS to be at least the largest endpoint number used.
+Then edit the ENDPOINT*_CONFIG lines so each endpoint is configured
+the proper way (transmit, receive, or both).
+
+The CONFIG_DESC_SIZE and any XYZ_DESC_OFFSET numbers must be
+edited to the correct sizes.  See usb_desc.c for the giant array
+of bytes.  Someday these may be done automatically..... (but how?)
+
+If you are using existing interfaces, the code in each file should
+automatically adapt to the changes you specify.  If you need to
+create a new type of interface, you'll need to write the code which
+sends and receives packets, and presents an API to the user.
+
+Finally, edit usb_inst.cpp, which creats instances of the C++
+objects for each combination.
+
+Some operating systems, especially Windows, may cache USB device
+info.  Changes to the device name may not update on the same
+computer unless the vendor or product ID numbers change, or the
+"bcdDevice" revision code is increased.
+
+If these instructions are missing steps or could be improved, please
+let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
+*/
+
+
+  #define MANUFACTURER_NAME     {'S','R','M',' ','+',' ','d','a','r','k','n','a', 'o'}
+  #define MANUFACTURER_NAME_LEN 13
+  #define PRODUCT_NAME          {'C', 'l', 'u', 'b', 'S', 'p', 'o', 'r', 't', ' ', 'W', 'h', 'e' ,'e', 'l'}
+  #define PRODUCT_NAME_LEN      15
+
+  #define EP0_SIZE              64
+  #define NUM_USB_BUFFERS       24
+
+
+/* USB version */
+#ifdef IS_USB
+  #define JOYSTICK_INTERFACE    0
+  #define JOYSTICK_ENDPOINT     1
+  #define JOYSTICK_SIZE         32
+  #define JOYSTICK_INTERVAL     2
+  #define LIGHTS_ENDPOINT       1
+  #define LIGHTS_SIZE           8
+  #define LIGHTS_INTERVAL       16
+  #define JOYSTICK_NAME         {'C', 'l', 'u', 'b', 'S', 'p', 'o', 'r', 't', ' ', 'W', 'h', 'e' ,'e', 'l'}
+  #define JOYSTICK_NAME_LEN     15
+
+  #define JOYSTICK_NUM_EP       2
+  #define JOYSTICK_NUM_INT      1
+
+
+#else
+  #define JOYSTICK_NUM_EP       0
+  #define JOYSTICK_NUM_INT      0
+#endif
+
+#ifdef HAS_DEBUG
+  #define VENDOR_ID   0x16C0
+  #define PRODUCT_ID    0x0487
+
+  #define SEREMU_NUM_EP       4
+  #define SEREMU_NUM_INT      2
+
+  #define DEVICE_CLASS    0xEF
+  #define DEVICE_SUBCLASS 0x02
+  #define DEVICE_PROTOCOL 0x01
+
+  #define CDC_IAD_DESCRIPTOR  1
+  #define CDC_STATUS_INTERFACE  0
+  #define CDC_DATA_INTERFACE  1 // Serial
+  #define CDC_ACM_ENDPOINT  2
+  #define CDC_RX_ENDPOINT       3
+  #define CDC_TX_ENDPOINT       4
+  #define CDC_ACM_SIZE          16
+  #define CDC_RX_SIZE           64
+  #define CDC_TX_SIZE           64
+#else
+  #define VENDOR_ID             0x0eb7
+  #define PRODUCT_ID            0x038e
+
+  #define SEREMU_NUM_EP       0
+  #define SEREMU_NUM_INT      0
+#endif
+
+  #define NUM_ENDPOINTS         JOYSTICK_NUM_EP + SEREMU_NUM_EP
+  #define NUM_INTERFACE         JOYSTICK_NUM_INT + SEREMU_NUM_INT
+
+
+  #define ENDPOINT1_CONFIG  ENDPOINT_TRANSMIT_AND_RECEIVE
+  #define ENDPOINT2_CONFIG  ENDPOINT_TRANSIMIT_ONLY
+  #define ENDPOINT3_CONFIG  ENDPOINT_RECEIVE_ONLY
+  #define ENDPOINT4_CONFIG  ENDPOINT_TRANSIMIT_ONLY
+  #define ENDPOINT5_CONFIG  ENDPOINT_TRANSIMIT_ONLY
+  #define ENDPOINT6_CONFIG  ENDPOINT_RECEIVE_ONLY
+
+
+#ifdef USB_DESC_LIST_DEFINE
+#if defined(NUM_ENDPOINTS) && NUM_ENDPOINTS > 0
+// NUM_ENDPOINTS = number of non-zero endpoints (0 to 15)
+extern const uint8_t usb_endpoint_config_table[NUM_ENDPOINTS];
+
+typedef struct {
+  uint16_t  wValue;
+  uint16_t  wIndex;
+  const uint8_t *addr;
+  uint16_t  length;
+} usb_descriptor_list_t;
+
+extern const usb_descriptor_list_t usb_descriptor_list[];
+#endif // NUM_ENDPOINTS
+#endif // USB_DESC_LIST_DEFINE
+#endif // USB_DISABLED
+
+
+#endif // F_CPU >= 20 MHz
+
+#endif


### PR DESCRIPTION
This adds a custom profile for the XBOX version of the USB Hub

It makes all of the buttons work including the rubber top ones.
Because there is a limit of 32 buttons for a standard windows game device some of the rubber buttons double up with the regular buttons as per the Fanatec manual... for example the 'A' rubber button is the same as the 'A' button in the bottom right group of three.

New firmware has been tested with Formula (F1), BMW and XBOX Hub.  I don't have the old HUB or the Porsche wheels, but am confident that this will not change anything for those.

Simon Maltby
Sim Racing Machines
www.simracingmachines.com/webshop